### PR TITLE
feat: add ability to reset injected answers

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -91,8 +91,12 @@ function inject(answers) {
   prompt._injected = (prompt._injected || []).concat(answers);
 }
 
+function resetInjectedAnswers() {
+  prompt._injected = [];
+}
+
 function override(answers) {
   prompt._override = Object.assign({}, answers);
 }
 
-module.exports = Object.assign(prompt, { prompt, prompts, inject, override });
+module.exports = Object.assign(prompt, { prompt, prompts, inject, resetInjectedAnswers, override });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@withgraphite/prompts",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Lightweight, beautiful and user-friendly prompts",
   "license": "MIT",
   "repository": {

--- a/test/prompts.js
+++ b/test/prompts.js
@@ -56,3 +56,28 @@ test('injects', t => {
         });
     });
 });
+
+test('resetInjectedAnswers', t => {
+  let injected = [ 1, 2, 3 ];
+  prompt.inject(injected);
+  t.same(prompt._injected, injected, 'injects array of answers');
+
+  prompt({ type: 'text', name:'a', message: 'a message' })
+    .then(foo => {
+      t.same(foo, { a:1 }, 'immediately returns object with injected answer');
+      t.same(prompt._injected, [ 2, 3 ], 'deletes the first answer from internal array');
+
+      prompt.resetInjectedAnswers();
+      t.same(prompt._injected, [], 'deletes everything from internal array');
+
+      let secondInjected = [ 4, 5 ];
+      prompt.inject(secondInjected)
+      t.same(prompt._injected, secondInjected, 'injects second array of answers');
+      prompt([{ type: 'text', name:'b', message: 'b message' }, { type: 'text', name:'c', message: 'c message' }])
+        .then(bar => {
+          t.same(bar, { b:4, c:5 }, 'immediately handles two prompts at once with new injected answers');
+          t.same(prompt._injected, [], 'leaves behind empty internal array when exhausted');
+          t.end();
+        });
+    });
+});


### PR DESCRIPTION
### what
add the ability to clear injected answers


### why

we use `prompt.inject` to inject answers for testing. however, if a test adds too many injections on accident that don't get used by the test, then this leaks over to the next test which which causes test failures. instead, we should be able to reset the injected answers before each test to make sure it's clean

I believe this is what's causing flaky tests in https://linear.app/withgraphite/issue/GT-10743/look-into-why-tests-involving-promptsinject-fail-in-ci 
