### PR TITLE
feat: add ctrl+u and ctrl+w support

### DIFF
--- a/lib/elements/text.js
+++ b/lib/elements/text.js
@@ -149,6 +149,43 @@ class TextPrompt extends Prompt {
     this.render();
   }
 
+  deleteToStart() {
+    if (this.isCursorAtStart() || this.placeholder) return this.bell();
+    let s2 = this.value.slice(this.cursor);
+    this.value = s2;
+    this.red = false;
+    this.cursor = 0;
+    this.cursorOffset = 0;
+    this.render();
+  }
+
+  deleteWord() {
+    if (this.isCursorAtStart() || this.placeholder) return this.bell();
+    let s1 = this.value.slice(0, this.cursor);
+    let s2 = this.value.slice(this.cursor);
+
+    // Find the start of the previous word
+    let i = s1.length - 1;
+
+    // Skip trailing whitespace
+    while (i >= 0 && /\s/.test(s1[i])) {
+      i--;
+    }
+
+    // Delete word characters
+    while (i >= 0 && !/\s/.test(s1[i])) {
+      i--;
+    }
+
+    let newS1 = s1.slice(0, i + 1);
+
+    this.value = `${newS1}${s2}`;
+    this.red = false;
+    this.cursor = newS1.length;
+    this.cursorOffset = 0;
+    this.render();
+  }
+
   first() {
     this.cursor = 0;
     this.render();

--- a/lib/util/action.js
+++ b/lib/util/action.js
@@ -11,6 +11,8 @@ module.exports = (key, isSelect) => {
     if (key.name === 'g') return 'reset';
     if (key.name === 'n') return 'down';
     if (key.name === 'p') return 'up';
+    if (key.name === 'u') return 'deleteToStart';
+    if (key.name === 'w') return 'deleteWord';
   }
   
   if (isSelect) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@withgraphite/prompts",
-  "version": "0.0.2",
+  "version": "0.0.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@withgraphite/prompts",
-      "version": "0.0.2",
+      "version": "0.0.5",
       "license": "MIT",
       "dependencies": {
         "kleur": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@withgraphite/prompts",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Lightweight, beautiful and user-friendly prompts",
   "license": "MIT",
   "repository": {

--- a/test/text.js
+++ b/test/text.js
@@ -57,3 +57,72 @@ test('submit', (t) => {
   t.same(textPrompt.cursorOffset, 0, 'cursorOffset is reset on submit')
   t.same(textPrompt.cursor, textPrompt.rendered.length, 'cursor is reset to end of line on submit')
 })
+
+test('deleteToStart', (t) => {
+  t.plan(6);
+
+  const textPrompt = new TextPrompt();
+  textPrompt.value = 'Hello, world!';
+  textPrompt.last();
+  textPrompt.render();
+
+  // Move cursor to middle of text
+  textPrompt.left();
+  textPrompt.left();
+  textPrompt.left();
+  textPrompt.left();
+  textPrompt.left();
+  textPrompt.left();
+  textPrompt.left();
+
+  t.same(textPrompt.cursor, 6, 'cursor is at position 6');
+
+  textPrompt.deleteToStart();
+  t.same(textPrompt.value, ' world!', 'text before cursor is deleted');
+  t.same(textPrompt.cursor, 0, 'cursor moved to start');
+  t.same(textPrompt.cursorOffset, 0, 'cursorOffset is 0');
+
+  // Test at start of line (should do nothing)
+  textPrompt.deleteToStart();
+  t.same(textPrompt.value, ' world!', 'text unchanged when at start');
+  t.same(textPrompt.cursor, 0, 'cursor still at start');
+
+  textPrompt.submit();
+  t.end();
+});
+
+test('deleteWord', (t) => {
+  t.plan(7);
+
+  const textPrompt = new TextPrompt();
+  textPrompt.value = 'Hello, world!';
+  textPrompt.last();
+  textPrompt.render();
+
+  // Delete last word
+  textPrompt.deleteWord();
+  t.same(textPrompt.value, 'Hello, ', 'last word deleted');
+  t.same(textPrompt.cursor, 7, 'cursor moved to end of remaining text');
+
+  // Delete remaining word
+  textPrompt.deleteWord();
+  t.same(textPrompt.value, '', 'all text deleted');
+  t.same(textPrompt.cursor, 0, 'cursor at start');
+
+  // Test with multiple spaces
+  textPrompt.value = 'one   two';
+  textPrompt.last();
+  textPrompt.render();
+
+  textPrompt.deleteWord();
+  t.same(textPrompt.value, 'one   ', 'word deleted, spaces remain');
+
+  // Test at start (should do nothing)
+  textPrompt.first();
+  textPrompt.deleteWord();
+  t.same(textPrompt.value, 'one   ', 'text unchanged when at start');
+  t.same(textPrompt.cursor, 0, 'cursor still at start');
+
+  textPrompt.submit();
+  t.end();
+});


### PR DESCRIPTION
Add ctrl+u (delete to start) and ctrl+w (delete previous word) support to prompts and tests for that functionality. This follows the behavior of my current zsh/kitty shell.

Bump version to 0.0.5 so when I publish I can bump the monologue version.

You can run the tests with `npm install`​ and `npm test`​ from the `test/`​ directory