### PR TITLE
fix: [CLI-273] Reset cursorOffset when moving cursor to first or last position

### DIFF
--- a/lib/elements/text.js
+++ b/lib/elements/text.js
@@ -188,11 +188,13 @@ class TextPrompt extends Prompt {
 
   first() {
     this.cursor = 0;
+    this.cursorOffset = 0;
     this.render();
   }
 
   last() {
     this.cursor = this.value.length;
+    this.cursorOffset = 0;
     this.render();
   }
 

--- a/test/text.js
+++ b/test/text.js
@@ -91,6 +91,44 @@ test('deleteToStart', (t) => {
   t.end();
 });
 
+test('first', (t) => {
+  t.plan(3);
+
+  const textPrompt = new TextPrompt();
+  textPrompt.value = 'Hello, world!';
+  textPrompt.last();
+  textPrompt.render();
+
+  // Nudge left so offset is non-zero, then verify reset on first()
+  textPrompt.left();
+  t.same(textPrompt.cursorOffset, -1, 'precondition: cursorOffset moved left');
+
+  textPrompt.first();
+  t.same(textPrompt.cursor, 0, 'cursor moved to start');
+  t.same(textPrompt.cursorOffset, 0, 'cursorOffset reset to 0');
+
+  t.end();
+});
+
+test('last', (t) => {
+  t.plan(3);
+
+  const textPrompt = new TextPrompt();
+  textPrompt.value = 'Hello, world!';
+  textPrompt.first();
+  textPrompt.render();
+
+  // Nudge right so offset is non-zero, then verify reset on last()
+  textPrompt.right();
+  t.same(textPrompt.cursorOffset, 1, 'precondition: cursorOffset moved right');
+
+  textPrompt.last();
+  t.same(textPrompt.cursor, textPrompt.rendered.length, 'cursor moved to end');
+  t.same(textPrompt.cursorOffset, 0, 'cursorOffset reset to 0');
+
+  t.end();
+});
+
 test('deleteWord', (t) => {
   t.plan(7);
 


### PR DESCRIPTION
### What Changed?

- reset cursor offset on first() and last()

### Why?

- if users do ctrl-a (start of line) ctrl-e (end of line) in a prompt, the cursor position moves correctly but the rendered caret doesnt move