### PR TITLE
fix: [CLI-273] use negative offset for first()

### DIFF
--- a/lib/elements/text.js
+++ b/lib/elements/text.js
@@ -188,7 +188,7 @@ class TextPrompt extends Prompt {
 
   first() {
     this.cursor = 0;
-    this.cursorOffset = 0;
+    this.cursorOffset = -this.rendered.length;
     this.render();
   }
 

--- a/test/text.js
+++ b/test/text.js
@@ -92,39 +92,63 @@ test('deleteToStart', (t) => {
 });
 
 test('first', (t) => {
-  t.plan(3);
+  t.plan(4);
 
   const textPrompt = new TextPrompt();
   textPrompt.value = 'Hello, world!';
   textPrompt.last();
   textPrompt.render();
 
-  // Nudge left so offset is non-zero, then verify reset on first()
-  textPrompt.left();
-  t.same(textPrompt.cursorOffset, -1, 'precondition: cursorOffset moved left');
+  // Move left repeatedly to the beginning to capture expected state
+  const length = textPrompt.rendered.length;
+  for (let i = 0; i < length; i++) {
+    textPrompt.left();
+  }
 
+  const expectedCursor = textPrompt.cursor;
+  const expectedOffset = textPrompt.cursorOffset;
+
+  t.same(expectedCursor, 0, 'manual movement reaches start');
+
+  // Reset to end and use first()
+  textPrompt.last();
+  textPrompt.render();
   textPrompt.first();
+
+  t.same(textPrompt.cursor, expectedCursor, 'first() cursor matches manual movement');
+  t.same(textPrompt.cursorOffset, expectedOffset, 'first() cursorOffset matches manual movement');
   t.same(textPrompt.cursor, 0, 'cursor moved to start');
-  t.same(textPrompt.cursorOffset, 0, 'cursorOffset reset to 0');
 
   t.end();
 });
 
 test('last', (t) => {
-  t.plan(3);
+  t.plan(4);
 
   const textPrompt = new TextPrompt();
   textPrompt.value = 'Hello, world!';
   textPrompt.first();
   textPrompt.render();
 
-  // Nudge right so offset is non-zero, then verify reset on last()
-  textPrompt.right();
-  t.same(textPrompt.cursorOffset, 1, 'precondition: cursorOffset moved right');
+  // Move right repeatedly to the end to capture expected state
+  const length = textPrompt.rendered.length;
+  for (let i = 0; i < length; i++) {
+    textPrompt.right();
+  }
 
+  const expectedCursor = textPrompt.cursor;
+  const expectedOffset = textPrompt.cursorOffset;
+
+  t.same(expectedCursor, textPrompt.rendered.length, 'manual movement reaches end');
+
+  // Reset to start and use last()
+  textPrompt.first();
+  textPrompt.render();
   textPrompt.last();
+
+  t.same(textPrompt.cursor, expectedCursor, 'last() cursor matches manual movement');
+  t.same(textPrompt.cursorOffset, expectedOffset, 'last() cursorOffset matches manual movement');
   t.same(textPrompt.cursor, textPrompt.rendered.length, 'cursor moved to end');
-  t.same(textPrompt.cursorOffset, 0, 'cursorOffset reset to 0');
 
   t.end();
 });


### PR DESCRIPTION
### What changed?

Changed the offset in `first()` to reflect that we are moving back by the rendered text length.

### Why?

In the rendering code, cursorOffset is used after rendering the text to move the cursor into the desired position. On first() we were incorrectly using a offset of 0 which would not move the caret. This resulted in the caret being stuck where it was (at the end of the line).

Used the script in the draft PR above to test:

[prompts_testing.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.stg.graphite.com/user-attachments/thumbnails/42757caa-0133-4e98-be5a-214e8ca54fe3.mov" />](https://app.stg.graphite.com/user-attachments/video/42757caa-0133-4e98-be5a-214e8ca54fe3.mov)

