### PR TITLE
Add CLI release workflow with beta/stable options

### DIFF
--- a/.github/workflows/cd-cli-release.yml
+++ b/.github/workflows/cd-cli-release.yml
@@ -1,0 +1,96 @@
+name: CD CLI Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_type:
+        description: 'Release type'
+        required: true
+        type: choice
+        options:
+          - beta
+          - stable
+          - beta-and-promote
+        default: beta
+      version:
+        description: 'Version to release (e.g., 1.0.0). For beta, will be published as 1.0.0-beta.X'
+        required: true
+        type: string
+
+jobs:
+  # Promote previous beta to stable (runs for 'stable' and 'beta-and-promote')
+  promote-beta-to-stable:
+    if: ${{ inputs.release_type == 'stable' || inputs.release_type == 'beta-and-promote' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Get current beta version
+        id: beta-version
+        run: |
+          BETA_VERSION=$(npm view @withgraphite/prompts dist-tags.beta 2>/dev/null || echo "")
+          if [ -z "$BETA_VERSION" ]; then
+            echo "No beta version found to promote"
+            exit 1
+          fi
+          echo "version=$BETA_VERSION" >> $GITHUB_OUTPUT
+          echo "Found beta version: $BETA_VERSION"
+
+      - name: Promote beta to stable
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          npm dist-tag add @withgraphite/prompts@${{ steps.beta-version.outputs.version }} latest
+          echo "Promoted ${{ steps.beta-version.outputs.version }} to stable (latest)"
+
+  # Release new beta version (runs for 'beta' and 'beta-and-promote')
+  release-beta:
+    needs: [promote-beta-to-stable]
+    # Run even if promote-beta-to-stable was skipped (for 'beta' only releases)
+    if: ${{ always() && (inputs.release_type == 'beta' || inputs.release_type == 'beta-and-promote') && (needs.promote-beta-to-stable.result == 'success' || needs.promote-beta-to-stable.result == 'skipped') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Determine beta version number
+        id: beta-number
+        run: |
+          # Get existing beta versions for this base version
+          EXISTING_BETAS=$(npm view @withgraphite/prompts versions --json 2>/dev/null | jq -r '.[]' | grep "^${{ inputs.version }}-beta\." | sort -V | tail -1 || echo "")
+          if [ -z "$EXISTING_BETAS" ]; then
+            BETA_NUM=0
+          else
+            # Extract the beta number and increment
+            BETA_NUM=$(echo "$EXISTING_BETAS" | sed 's/.*-beta\.//' | awk '{print $1 + 1}')
+          fi
+          FULL_VERSION="${{ inputs.version }}-beta.${BETA_NUM}"
+          echo "version=$FULL_VERSION" >> $GITHUB_OUTPUT
+          echo "Will publish beta version: $FULL_VERSION"
+
+      - name: Update package version
+        run: npm version ${{ steps.beta-number.outputs.version }} --no-git-tag-version
+
+      - name: Publish beta to npm
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --tag beta
+
+      - name: Output published version
+        run: echo "Published @withgraphite/prompts@${{ steps.beta-number.outputs.version }} with tag 'beta'"


### PR DESCRIPTION
This PR was created by a Graphite background agent: https://app.stg.graphite.com/background-agents/withgraphite/prompts/task/bgt_01kcktcb4wfggb2g4f4bynqcke

  > refactor cd-cli-release.yml so that releasing the beta version and rolling over the previous beta to stable can be achieved in one step